### PR TITLE
Handle case where endpoint path has embedded query string

### DIFF
--- a/Horatio/Services/ServiceRequestConfigurator.swift
+++ b/Horatio/Services/ServiceRequestConfigurator.swift
@@ -26,7 +26,10 @@ public extension ServiceRequestConfigurator {
                 for transformer in endpointPathTransformers(serviceRequest) {
                     components = transformer.transformedPath(components)
                 }
-                
+
+                // must do this after transforms have happened
+                rectifyEmbeddedQuery(components)
+
                 return components.URL
 
             case .absolutePath(let urlString):
@@ -47,6 +50,32 @@ public extension ServiceRequestConfigurator {
         }
 
         return urlRequest
+    }
+
+    /**
+     Handles the case where there are query parameters embedded in the path. Properly
+     pulls them out and merges them into the query.
+     */
+    private func rectifyEmbeddedQuery(components: NSURLComponents) {
+        guard let path = components.path, range = path.rangeOfString("?") else { return }
+
+        components.path = path.substringToIndex(range.startIndex)
+        let queryString = path.substringFromIndex(range.startIndex.advancedBy(1))
+
+        var queryItems = [NSURLQueryItem]()
+
+        if let existingQuery = components.queryItems {
+            queryItems.appendContentsOf(existingQuery)
+        }
+
+        // let it parse the query for us
+        components.query = queryString
+
+        if let newQuery = components.queryItems {
+            queryItems.appendContentsOf(newQuery)
+        }
+
+        components.queryItems = queryItems
     }
 }
 


### PR DESCRIPTION
An example endpoint definition from NBA that hits this use case:

```
"tntOt": {
        "host": "api.qa.nba.net",
        "path": "0/league/stream/87db8aca-b979-409f-b4c6-9d29efe444be?games={{gameID}}"
}
```