### PR TITLE
Fix inverted logic in NetworkObserver

### DIFF
--- a/Horatio/Operations/NetworkObserver.swift
+++ b/Horatio/Operations/NetworkObserver.swift
@@ -109,12 +109,15 @@ fileprivate class NetworkObserverTimer {
     // MARK: Initialization
 
     init(interval: TimeInterval, handler: @escaping ()->()) {
-        let when = DispatchTime.now() + Double(Int64(interval * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-
-        DispatchQueue.main.asyncAfter(deadline: when) { [weak self] in
-            if self?.isCancelled == true {
-                handler()
+        DispatchQueue.main.asyncAfter(deadline: .now() + interval) { [weak self] in
+            guard
+                let strongSelf = self,
+                strongSelf.isCancelled == false
+            else {
+                return
             }
+
+            handler()
         }
     }
 

--- a/Horatio/Operations/URLSessionTaskOperation.swift
+++ b/Horatio/Operations/URLSessionTaskOperation.swift
@@ -30,6 +30,9 @@ open class URLSessionTaskOperation: Operation {
         self.task = task
 
         super.init()
+
+        let networkObserver = NetworkObserver()
+        self.addObserver(networkObserver)
     }
 
     override open func execute() {


### PR DESCRIPTION
The logic in NetworkObserverTimer was inverted, such that it would only execute its handler if it was cancelled.

I also added a NetworkObserver to URLSessionTaskOperation. If you don't think that's appropriate for the stock Horatio library, we can discard that change.