### PR TITLE
Cocoa pod support

### DIFF
--- a/Horatio.podspec
+++ b/Horatio.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'Horatio'
-  s.version = '0.3.0'
+  s.version = '0.3'
 
   s.ios.deployment_target = '9.0'
 

--- a/Horatio.podspec
+++ b/Horatio.podspec
@@ -1,0 +1,70 @@
+Pod::Spec.new do |s|
+  s.name = 'Horatio'
+  s.version = '0.3.0'
+
+  s.ios.deployment_target = '9.0'
+
+  s.license = 'MIT'
+  s.summary = 'Horatio is a library of patterns, protocols, and classes typical for the "skeleton" of a modern app.'  
+  s.homepage = 'https://github.com/ktatroe/MPA-Horatio'
+  s.author = { 'Kevin Tatroe' => 'support@mudpotapps.com' }
+  s.source = { :git => 'https://github.com/ktatroe/MPA-Horatio.git', :tag => s.version.to_s }
+
+  s.description = 'Operations queue with conditions, observers, and improved error handling ' \
+				  '(based on Apple’s \"Advanced NSOperations\" sample code). ' \
+				  'HTTP requests for standard REST services. ' \
+				  'An injection container. ' \
+				  'A feature availability system for global or per-subject behaviors.'  
+
+  s.requires_arc = true
+  
+  s.default_subspec = 'Core'
+
+  s.subspec 'Core' do |core|
+    core.source_files = 'Horatio/Horatio/**/*.{h,swift}'
+    core.exclude_files = 'Horatio/Horatio/Classes/Operations/{Calendar,CKContainer,Cloud,Health,Location,Passbook,Photos,Remote,UIUser,User}*.swift'
+  end
+
+  s.subspec 'EventKit' do |event|
+    event.source_files = 'Horatio/Horatio/Classes/Operations/{Calendar}*.swift'
+	event.framework = 'EventKit'
+    event.dependency 'Horatio/Core'
+  end
+
+  s.subspec 'CloudKit' do |cloud|
+    cloud.source_files = 'Horatio/Horatio/Classes/Operations/{CKContainer,Cloud}*.swift'
+    cloud.framework = 'CloudKit'
+    cloud.dependency 'Horatio/Core'
+  end
+
+  s.subspec 'HealthKit' do |health|
+    health.source_files = 'Horatio/Horatio/Classes/Operations/{Health}*.swift'
+	health.framework = 'HealthKit'
+    health.dependency 'Horatio/Core'
+  end
+
+  s.subspec 'CoreLocation' do |loc|
+    loc.source_files = 'Horatio/Horatio/Classes/Operations/{Location}*.swift'
+	loc.framework = 'CoreLocation'
+    loc.dependency 'Horatio/Core'
+  end
+
+  s.subspec 'PassKit' do |pass|
+    pass.source_files = 'Horatio/Horatio/Classes/Operations/{Passbook}*.swift'
+	pass.framework = 'PassKit'
+    pass.dependency 'Horatio/Core'
+  end
+
+  s.subspec 'Photos' do |photos|
+    photos.source_files = 'Horatio/Horatio/Classes/Operations/{Photos}*.swift'
+	photos.framework = 'Photos'
+    photos.dependency 'Horatio/Core'
+  end
+
+  s.subspec 'Notifications' do |notif|
+    notif.source_files = 'Horatio/Horatio/Classes/Operations/{Remote,UIUser,User}*.swift'
+	notif.framework = 'UserNotifications'
+    notif.dependency 'Horatio/Core'
+  end
+
+end

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2016-2017 Kevin Tatroe support@mudpotapps.com
+ 
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+ 
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+ 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+


### PR DESCRIPTION
Adding a pod spec file to allow the repository to be added to Cocoa Pods distributions.

There are individual subspecs that separate out all of the optional classes that require special user permissions and strings for App Store submission. Each subspec can be used independently or combined through multiple pod file entries.

Added the default MIT license as well so that the spec will validate correctly without warnings when you run 'pod lib lint'.

Version is set to 0.3 but can be changed to whatever it needs to be for the next release tag.