### PR TITLE
update KVO mechanism and implement keyPathsForValuesAffectingValue

### DIFF
--- a/Horatio/Horatio/Classes/Operations/Operation.swift
+++ b/Horatio/Horatio/Classes/Operations/Operation.swift
@@ -16,6 +16,17 @@ import Foundation
  */
 open class Operation: Foundation.Operation {
 
+    // use the KVO mechanism to indicate that changes to "state" affect other properties as well
+    override open class func keyPathsForValuesAffectingValue(forKey key: String) -> Set<String> {
+        var set = super.keyPathsForValuesAffectingValue(forKey: key)
+
+        if key == "isReady" || key == "isExecuting" || key == "isFinished" || key == "isCancelled" {
+            set.insert("state")
+        }
+
+        return set
+    }
+
     // MARK: State Management
     
     fileprivate enum State: Int, Comparable {
@@ -45,19 +56,6 @@ open class Operation: Foundation.Operation {
         
         /// The `Operation` has finished executing.
         case finished
-
-        func keyPathForKeyValueObserving() -> String? {
-            switch self {
-            case .ready:
-                return "isReady"
-
-            case .finished:
-                return "isFinished"
-
-            default:
-                return nil
-            }
-        }
         
         func canTransitionToState(_ target: State) -> Bool {
             switch (self, target) {
@@ -115,12 +113,6 @@ open class Operation: Foundation.Operation {
              */
             willChangeValue(forKey: "state")
 
-            let newStateKeyPath = newState.keyPathForKeyValueObserving()
-
-            if let path = newStateKeyPath {
-                willChangeValue(forKey: path)
-            }
-
             stateLock.withCriticalScope { () -> Void in
                 guard _state != .finished else {
                     return
@@ -129,10 +121,6 @@ open class Operation: Foundation.Operation {
                 assert(_state.canTransitionToState(newState), "Performing invalid state transition.")
 
                 _state = newState
-            }
-
-            if let path = newStateKeyPath {
-                didChangeValue(forKey: path)
             }
 
             didChangeValue(forKey: "state")


### PR DESCRIPTION
Addresses an issue with Swift 4 beta 5 where asserts were being hit transitioning from various states