### PR TITLE
Fix invalid operation transitions in Xcode 9

### DIFF
--- a/Horatio/Horatio/Classes/Operations/NSLock+Operations.swift
+++ b/Horatio/Horatio/Classes/Operations/NSLock+Operations.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-extension NSLock {
+extension NSLocking {
     func withCriticalScope<T>(_ block: () -> T) -> T {
         lock()
         let value = block()


### PR DESCRIPTION
As soon as we started building with Xcode 9, we saw frequent assertion failures (and crashes) due to invalid state transitions in Operation. Particularly for `evaluatingConditions` to `evaluatingConditions`.

This appears to be due to a threading bug regarding the `state` variable. In a few places we were reading the variable, then making a decision and writing to the variable (particularly with `evaluateConditions()`). But without a lock around that critical section, another thread was able to come in and also change the state in the middle of that process.