### PR TITLE
Fix error handling bug in ServiceRequestOperation

### DIFF
--- a/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
+++ b/Horatio/Horatio/Classes/Services/ServiceRequestOperation.swift
@@ -92,9 +92,8 @@ open class DownloadServiceResponseOperation: GroupOperation {
 
                 let task = URLSession.shared.downloadTask(with: urlRequest, completionHandler: { [weak self] (url, response, error) -> Void in
                     guard let weakSelf = self else { return }
-                    guard let response = response as? HTTPURLResponse else { weakSelf.finish(); return }
 
-                    weakSelf.downloadFinished(url, response: response, error: error as NSError?)
+                    weakSelf.downloadFinished(url, response: response as? HTTPURLResponse, error: error as NSError?)
                 })
 
                 let taskOperation = URLSessionTaskOperation(task: task)


### PR DESCRIPTION
The existing code would cause connection errors to go unreported. Because `response` would be nil, and therefore the cast to `HTTPURLResponse` would fail.