### PR TITLE
Fix/json parser lockup

### DIFF
--- a/Horatio/Horatio.xcodeproj/project.pbxproj
+++ b/Horatio/Horatio.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4FB1ABC2207EF53000C78406 /* JSONParsingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FB1ABC1207EF53000C78406 /* JSONParsingTests.swift */; };
 		EDB7F4271EC211DD0037CCB3 /* Horatio.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EDB7F41D1EC211DD0037CCB3 /* Horatio.framework */; };
 		EDB7F42C1EC211DD0037CCB3 /* HoratioTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDB7F42B1EC211DD0037CCB3 /* HoratioTests.swift */; };
 		EDB7F42E1EC211DD0037CCB3 /* Horatio.h in Headers */ = {isa = PBXBuildFile; fileRef = EDB7F4201EC211DD0037CCB3 /* Horatio.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -71,6 +72,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4FB1ABC1207EF53000C78406 /* JSONParsingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParsingTests.swift; sourceTree = "<group>"; };
 		EDB7F41D1EC211DD0037CCB3 /* Horatio.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Horatio.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EDB7F4201EC211DD0037CCB3 /* Horatio.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Horatio.h; sourceTree = "<group>"; };
 		EDB7F4211EC211DD0037CCB3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -157,6 +159,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4FB1ABC0207EF51300C78406 /* JSON */ = {
+			isa = PBXGroup;
+			children = (
+				4FB1ABC1207EF53000C78406 /* JSONParsingTests.swift */,
+			);
+			path = JSON;
+			sourceTree = "<group>";
+		};
 		EDB7F4131EC211DD0037CCB3 = {
 			isa = PBXGroup;
 			children = (
@@ -190,6 +200,7 @@
 		EDB7F42A1EC211DD0037CCB3 /* HoratioTests */ = {
 			isa = PBXGroup;
 			children = (
+				4FB1ABC0207EF51300C78406 /* JSON */,
 				EDB7F42B1EC211DD0037CCB3 /* HoratioTests.swift */,
 				EDB7F42D1EC211DD0037CCB3 /* Info.plist */,
 			);
@@ -492,6 +503,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4FB1ABC2207EF53000C78406 /* JSONParsingTests.swift in Sources */,
 				EDB7F42C1EC211DD0037CCB3 /* HoratioTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Horatio/Horatio/Classes/JSON/JSONParsing.swift
+++ b/Horatio/Horatio/Classes/JSON/JSONParsing.swift
@@ -215,7 +215,7 @@ extension String {
 
         func decodeEntity(_ entity: String) -> Character? {
             if entity.hasPrefix("\\x") || entity.hasPrefix("\\u") {
-                return decodeHexValue(entity.substring(from: entity.characters.index(entity.startIndex, offsetBy: 2)), base: 16)
+                return decodeHexValue(entity.substring(from: entity.index(entity.startIndex, offsetBy: 2)), base: 16)
             }
 
             return nil
@@ -232,7 +232,7 @@ extension String {
                 position = entityRange.lowerBound
 
                 let entityLength = (beacon == "\\u") ? 4 : 2
-                let entity = self[position ..< self.characters.index(position, offsetBy: entityLength)]
+                let entity = self[position ..< self.index(position, offsetBy: entityLength)]
 
                 if let decodedEntity = decodeEntity(String(entity)) {
                     result.append(decodedEntity)

--- a/Horatio/Horatio/Classes/JSON/JSONParsing.swift
+++ b/Horatio/Horatio/Classes/JSON/JSONParsing.swift
@@ -239,6 +239,8 @@ extension String {
                 } else {
                     result.append(String(entity))
                 }
+                
+                position = self.index(after: position)
             }
         }
 

--- a/Horatio/HoratioTests/JSON/JSONParsingTests.swift
+++ b/Horatio/HoratioTests/JSON/JSONParsingTests.swift
@@ -1,0 +1,72 @@
+//
+//  JSONParsingTests.swift
+//  HoratioTests
+//
+//  Created by Ryan Carlson on 4/11/18.
+//  Copyright © 2018 Mudpot Apps. All rights reserved.
+//
+
+import XCTest
+import Horatio
+
+class JSONParsingTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testSimpleString() {
+        let str = "abcd"
+        
+        let parsedString = JSONParser.parseString(str)
+        
+        XCTAssertEqual(str, parsedString)
+    }
+    
+    func testJSONString() {
+        let str = "{ abcd }"
+        
+        let parsedString = JSONParser.parseString(str)
+        
+        XCTAssertEqual(str, parsedString)
+    }
+    
+    func testJSONObjectWithoutQuotes() {
+        let str = "{ abc: efg }"
+        
+        let parsedString = JSONParser.parseString(str)
+        
+        XCTAssertEqual(str, parsedString)
+    }
+    
+    func testNestedJSONObjectWithoutQuotes() {
+        let str = "{ abc: efg, x: { y: z } }"
+        
+        let parsedString = JSONParser.parseString(str)
+        
+        XCTAssertEqual(str, parsedString)
+    }
+    
+    func testJSONObjectWithQuotes() {
+        let str = "{ \"abc\": \"efg\" }"
+        
+        let parsedString = JSONParser.parseString(str)
+        
+        XCTAssertEqual(str, parsedString)
+    }
+    
+    /* this string has an instance of \\u which caused Cru's app to lock up */
+    func testOffendingString() {
+        let str = "{ abc: \\uxyz \"efg\" }"
+        
+        let parsedString = JSONParser.parseString(str)
+        
+        XCTAssertEqual(str, parsedString)
+    }
+}


### PR DESCRIPTION
The inner while loop can turn into an infinite loop when the string being evaluated has an instance of `\\u` or `\\w` in it.

This fix, while not perfect, avoids the infinite loop by moving the `Index` position one place ahead. The final test in this PR does fail b/c the decoder translates \u into some foreign language character.

I'm not sure what the original author was intending to do with this function. I'm not sure what \\x or \\u represents.. an encoded ?? So, this fix may not be the right fix, but it does prevent an infinite loop in this case and still translates many common/simple strings just fine.